### PR TITLE
Hotfix: Allow Apply Script quick pick to be dismissed

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -314,7 +314,10 @@ async function applyScript(scriptFile?: ScriptFile) {
     }), {
       placeHolder: 'Select a script to apply'
     }).then(async scriptChoice => {
-        applyScript(scriptChoice?.data);
+      if (!scriptChoice?.data) {
+        return;
+      }
+      applyScript(scriptChoice.data);
     });
   }
 


### PR DESCRIPTION
Hi again! Love all the new changes that have been made to Scriptify.

I noticed that when doing the Apply Script action, if you try to dismiss the quick pick using "Esc" it doesn't go away. You have to choose a script for it to go away. Thought I'd fix it! 😉 