### PR TITLE
Extension fails to activate when no folder/multiple folders open in workspace

### DIFF
--- a/extension/src/classes/Scriptify.ts
+++ b/extension/src/classes/Scriptify.ts
@@ -2,7 +2,7 @@ import { getWorkspaceFolder, getVersion } from "../utils";
 
 export class Scriptify {
 
-  workspaceFolder = getWorkspaceFolder();
+  workspaceFolder = getWorkspaceFolder(true);
 
   /** Current extension version */
   version = getVersion();


### PR DESCRIPTION
Hi again @imike57,

I often have multiple folders open in one workspace on VSCode. I noticed that when I'm using this workspace, none of the Scriptify functions work, it throws the error "command not found".  The reason this happens is in the `Scriptify` class initialization, when `getWorkspaceFolder` is called, an error is thrown if there are no folders open or multiple folders open. Then extension activation fails after that, so no functions are registered.

My solution was to simply put `true` in the `getWorkspaceFolder()` call, so the errors are ignored. I don't know if that's the best solution, but just wanted to let you know of this bug!

Thanks!